### PR TITLE
Add IndieList to Market Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ ______________________________________________________________________
 
 - [Euro-Monitor, Video Games](https://www.euromonitor.com/) - Strategic Market Researcher.
 - [Grand View Research, Digital Media](https://www.grandviewresearch.com/industry/digital-media) - Syndicated market research studies.
+- [IndieList](https://indielist.games/) - Indie game, studio, publisher, and funding relationship data with transparent sales estimates and market research tools.
 - [Newzoo](https://newzoo.com/) - View on the games market. Unparalleled insights and value.
 - [Statista, Video Games](https://www.statista.com/topics/868/video-games/) - Market and opinion research institutes and data derived from the economic sector.
 


### PR DESCRIPTION
### What this adds

Adds IndieList to the Market Research section. IndieList is free to use and maps indie games, studios, publishers, and funding relationships, with documented white-box sales estimates across more than 3,800 published titles.

### Affiliation

I am submitting this on behalf of the IndieList project.

I checked the contribution guidelines, kept the requested format and alphabetical order, and verified that the repository did not already contain `indielist.games`.