### PR TITLE
Add VGLocations dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ ______________________________________________________________________
 - [The Complete Pokemon Dataset](https://www.kaggle.com/datasets/rounakbanik/pokemon) - Pokemon data from all generations.
 - [The Quick, Draw! Dataset](https://github.com/googlecreativelab/quickdraw-dataset) - Collection of 50 million drawings across 345 categories.
 - [Travian buildings](https://www.kaggle.com/cblesa/travian-buildings) - Time, cost and bonus of buildings.
+- [VGLocations Public Preview Dataset](https://vglocations.org/video-game-locations-datasets/) - A curated geospatial dataset of real-world video game locations, with free CSV releases containing up to 3,000 locations.
 - [World of Warcraft Avatar History](https://www.kaggle.com/mylesoneill/warcraft-avatar-history) - Collection of records.
 - [World of Warcraft Battlegrounds](https://www.kaggle.com/cblesa/world-of-warcraft-battlegrounds) - Details of battlegrounds.
 


### PR DESCRIPTION
This pull request adds VGLocations, a curated geospatial dataset documenting real-world locations represented in video games.

The dataset includes game titles, franchises, real-world locations, countries, coordinates, location types, setting status, coordinate methods, and verification metadata.

Free public datasets are available through the official project website, including releases with up to 3,000 locations.

Resources:

- Website: https://vglocations.org/
- Dataset page: https://vglocations.org/video-game-locations-datasets/
- Hugging Face: https://huggingface.co/datasets/theonlyduck/vglocations-public-preview/
- Zenodo: https://zenodo.org/records/21838941
- Kaggle: https://www.kaggle.com/datasets/theonlyduck/vglocations-public-preview-dataset/data
- GitHub repository: https://github.com/theonlyduck/vglocations